### PR TITLE
Fix path for step 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ git clone git@github.com:rezaali/Watchdog.git Watchdog
 
 #### 4. Build Cinder
 ```
-cd ../proj/xcode/ && ./fullbuild.sh
+cd ../../proj/xcode/ && ./fullbuild.sh
 ```
 
 #### 5. Open Fragment Xcode project


### PR DESCRIPTION
Little typo while going through this myself: the command for going back and building Cinder (step `.4`) is short one level, so this tiny PR prepends `../` to it :)